### PR TITLE
[refactor] 챌린지 통계 로직 서비스 단에서 분리

### DIFF
--- a/src/main/java/ssafy/haruman/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/ssafy/haruman/domain/challenge/controller/ChallengeController.java
@@ -11,6 +11,7 @@ import ssafy.haruman.domain.challenge.dto.request.ExpenseUpdateRequestDto;
 import ssafy.haruman.domain.challenge.dto.response.*;
 import ssafy.haruman.domain.challenge.service.ChallengeService;
 import ssafy.haruman.domain.challenge.service.ExpenseService;
+import ssafy.haruman.domain.challenge.service.StatsService;
 import ssafy.haruman.domain.member.entity.Member;
 import ssafy.haruman.global.response.JsonResponse;
 import ssafy.haruman.global.response.PageInfo;
@@ -27,6 +28,7 @@ public class ChallengeController {
 
     private final ChallengeService challengeService;
     private final ExpenseService expenseService;
+    private final StatsService statsService;
 
     @PostMapping
     public ResponseEntity<ResponseWrapper<DailyChallengeResponseDto>> startChallenge(
@@ -53,7 +55,7 @@ public class ChallengeController {
     @GetMapping("/people")
     public ResponseEntity<ResponseWrapper<List<ChallengeUserListResponseDto>>> selectChallengeUserList() {
 
-        List<ChallengeUserListResponseDto> userList = challengeService.selectChallengeUserList();
+        List<ChallengeUserListResponseDto> userList = statsService.selectChallengeUserList();
 
         int size = 0;
         for (ChallengeUserListResponseDto group : userList) {
@@ -69,7 +71,7 @@ public class ChallengeController {
     public ResponseEntity<ResponseWrapper<AccumulatedAmountResponseDto>> selectAccumulatedAmount(
             @AuthenticationPrincipal Member member) {
 
-        AccumulatedAmountResponseDto accumulatedAmount = challengeService.selectAccumulatedAmount(member.getProfile());
+        AccumulatedAmountResponseDto accumulatedAmount = statsService.selectAccumulatedAmount(member.getProfile());
 
         return JsonResponse.ok("챌린지 누적 잔액을 성공적으로 가져왔습니다.", accumulatedAmount);
     }
@@ -81,7 +83,7 @@ public class ChallengeController {
             @DateTimeFormat(pattern = "yyyy-MM") Date yearAndMonth) {
 
         List<ChallengeHistoryResponseDto> challengeHistory =
-                challengeService.selectChallengeHistory(member.getProfile(), yearAndMonth);
+                statsService.selectChallengeHistory(member.getProfile(), yearAndMonth);
 
         PageInfo listSize = PageInfo.builder().size(challengeHistory.size()).build();
 

--- a/src/main/java/ssafy/haruman/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/ssafy/haruman/domain/challenge/service/ChallengeService.java
@@ -24,10 +24,4 @@ public interface ChallengeService {
     void preRecommend() throws IOException;
 
     void depositRecommend(Challenge challenge) throws IOException;
-
-    List<ChallengeUserListResponseDto> selectChallengeUserList();
-
-    AccumulatedAmountResponseDto selectAccumulatedAmount(Profile profile);
-
-    List<ChallengeHistoryResponseDto> selectChallengeHistory(Profile profile, Date yearAndMonth);
 }

--- a/src/main/java/ssafy/haruman/domain/challenge/service/StatsService.java
+++ b/src/main/java/ssafy/haruman/domain/challenge/service/StatsService.java
@@ -1,0 +1,18 @@
+package ssafy.haruman.domain.challenge.service;
+
+import ssafy.haruman.domain.challenge.dto.response.AccumulatedAmountResponseDto;
+import ssafy.haruman.domain.challenge.dto.response.ChallengeHistoryResponseDto;
+import ssafy.haruman.domain.challenge.dto.response.ChallengeUserListResponseDto;
+import ssafy.haruman.domain.profile.entity.Profile;
+
+import java.util.Date;
+import java.util.List;
+
+public interface StatsService {
+
+    List<ChallengeUserListResponseDto> selectChallengeUserList();
+
+    AccumulatedAmountResponseDto selectAccumulatedAmount(Profile profile);
+
+    List<ChallengeHistoryResponseDto> selectChallengeHistory(Profile profile, Date yearAndMonth);
+}

--- a/src/main/java/ssafy/haruman/domain/challenge/service/StatsServiceImpl.java
+++ b/src/main/java/ssafy/haruman/domain/challenge/service/StatsServiceImpl.java
@@ -1,0 +1,80 @@
+package ssafy.haruman.domain.challenge.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import ssafy.haruman.domain.challenge.dto.response.AccumulatedAmountResponseDto;
+import ssafy.haruman.domain.challenge.dto.response.ChallengeHistoryResponseDto;
+import ssafy.haruman.domain.challenge.dto.response.ChallengeUserInfoDto;
+import ssafy.haruman.domain.challenge.dto.response.ChallengeUserListResponseDto;
+import ssafy.haruman.domain.challenge.entity.Challenge;
+import ssafy.haruman.domain.challenge.entity.ChallengeGroup;
+import ssafy.haruman.domain.challenge.repository.ChallengeRepository;
+import ssafy.haruman.domain.challenge.repository.ChallengeUserInfoMapping;
+import ssafy.haruman.domain.profile.entity.Profile;
+import ssafy.haruman.global.service.S3FileService;
+
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class StatsServiceImpl implements StatsService {
+
+    private final ChallengeRepository challengeRepository;
+    private final S3FileService s3FileService;
+
+
+    @Override
+    public List<ChallengeUserListResponseDto> selectChallengeUserList() {
+
+        List<ChallengeUserInfoMapping> challengeList = challengeRepository.findChallengeAndExpenseAndProfileByStatus();
+
+        return challengeList.stream()
+                .collect(Collectors.groupingBy(this::getGroupKey))
+                .entrySet().stream()
+                .map(entry -> ChallengeUserListResponseDto.from(entry.getKey(), convertToUserInfoDto(entry.getValue())))
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public AccumulatedAmountResponseDto selectAccumulatedAmount(Profile profile) {
+
+        Integer accumulatedAmount = challengeRepository.sumByProfileAndStatus(profile.getId());
+
+        return AccumulatedAmountResponseDto.builder().accumulatedAmount(accumulatedAmount).build();
+    }
+
+    @Override
+    public List<ChallengeHistoryResponseDto> selectChallengeHistory(Profile profile, Date yearAndMonth) {
+
+        DateFormat dateFormat = new SimpleDateFormat("yyyy-MM");
+        String date = yearAndMonth == null ?
+                LocalDate.now().format(DateTimeFormatter.ofPattern("yyyy-MM")) : dateFormat.format(yearAndMonth);
+
+        List<Challenge> challengeList = challengeRepository.findAllByProfileAndDate(profile.getId(), date);
+
+        return challengeList.stream()
+                .map(ChallengeHistoryResponseDto::from)
+                .collect(Collectors.toList());
+    }
+
+    private String getGroupKey(ChallengeUserInfoMapping challenge) {
+        ChallengeGroup group = ChallengeGroup.getGroup(challenge.getUsedAmount());
+        return group.getGroupKey();
+    }
+
+    private List<ChallengeUserInfoDto> convertToUserInfoDto(List<ChallengeUserInfoMapping> list) {
+        return list.stream()
+                .map(item -> {
+
+                    String profileImageUrl = s3FileService.getS3Url(item.getProfileImagePath(), item.getProfileImageName());
+                    return ChallengeUserInfoDto.from(item, profileImageUrl);
+                })
+                .collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
## Work Description ✏️

- 기존에 챌린지 서비스 내에 포함되어 있던 통계 관련 로직을 별도의 서비스로 분리하였습니다.
- 코드 가독성과 원활한 협업을 위해 분리가 필요하다고 판단되어 분리하였습니다.

## Share 🤔

- 트랜잭션 처리에 대해서 공부하면서 이후 리팩토링을 진행해야 할 것 같습니다.

## Related issue 🛠

- Closes #2 
